### PR TITLE
Form Identifier String Bugfix for Preset JSON

### DIFF
--- a/src/RaceMenuVRHooks.h
+++ b/src/RaceMenuVRHooks.h
@@ -120,7 +120,7 @@ namespace RaceMenuVRHooks
 			if (modInfo) {
 				sprintf_s(formName, "%s|%06X", modInfo->fileName, modForm);
 			}
-			strncpy(extraOutput,formName,strlen(formName));)
+			strncpy(extraOutput,formName,strlen(formName));
 			return formName;
 		}
 

--- a/src/RaceMenuVRHooks.h
+++ b/src/RaceMenuVRHooks.h
@@ -103,7 +103,7 @@ namespace RaceMenuVRHooks
 
 	namespace FileLookupHooks
 	{
-		std::string GetFormIdentifier(char* extraOutput, RE::TESForm* form)
+		std::string GetFormIdentifier(RE::TESForm* form)
 		{
 			char formName[MAX_PATH];
 			std::uint8_t modIndex = form->formID >> 24;
@@ -120,7 +120,6 @@ namespace RaceMenuVRHooks
 			if (modInfo) {
 				sprintf_s(formName, "%s|%06X", modInfo->fileName, modForm);
 			}
-			strncpy(extraOutput,formName,strlen(formName));
 			return formName;
 		}
 

--- a/src/RaceMenuVRHooks.h
+++ b/src/RaceMenuVRHooks.h
@@ -103,7 +103,7 @@ namespace RaceMenuVRHooks
 
 	namespace FileLookupHooks
 	{
-		std::string GetFormIdentifier(void* a_unk, RE::TESForm* form)
+		std::string GetFormIdentifier(char* extraOutput, RE::TESForm* form)
 		{
 			char formName[MAX_PATH];
 			std::uint8_t modIndex = form->formID >> 24;
@@ -120,7 +120,7 @@ namespace RaceMenuVRHooks
 			if (modInfo) {
 				sprintf_s(formName, "%s|%06X", modInfo->fileName, modForm);
 			}
-
+			strncpy(extraOutput,formName,strlen(formName));)
 			return formName;
 		}
 


### PR DESCRIPTION
a_unk is actually the string pointer for the return value, only form is needed because of C++ ABI afaik, please do not merge until it is tested to see if it fixes the bugs with the preset JSON.